### PR TITLE
Export RendererOption, ProviderOption, ProviderResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is alternative implementation for [b24.js](https://github.com/xqq/b24.js).
 
 ## Options
 
-* data_identifer: Specify number 0x80 (caption) or 0x81 (superimpose). default: 0x80 (caption)
+* data_identifier: Specify number 0x80 (caption) or 0x81 (superimpose). default: 0x80 (caption)
 * data_group_id: Specify number 0x01 (1st language) or 0x02 (2nd language). default: 0x01 (1st language)
 * forceStrokeColor: Specify a color for always drawing character's stroke.
 * forceBackgroundColor: Specify a color for always drawing character's background

--- a/src/canvas-provider.ts
+++ b/src/canvas-provider.ts
@@ -23,7 +23,7 @@ import MD5 from './utils/md5'
 const SIZE_MAGNIFICATION = 2; // 奇数の height 時に SSZ で改行を行う場合があるため、全体をN倍して半分サイズに備える
 let EMBEDDED_GLYPH: Map<string, PathElement> | null = null;
 
-interface ProviderOption {
+export interface ProviderOption {
   canvas?: HTMLCanvasElement,
   width?: number,
   height?: number,
@@ -40,7 +40,7 @@ interface ProviderOption {
   usePUA?: boolean,
 }
 
-interface ProviderResult {
+export interface ProviderResult {
   startTime: number,
   endTime: number,
   PRA: number | null

--- a/src/canvas-renderer.ts
+++ b/src/canvas-renderer.ts
@@ -5,7 +5,7 @@ import { readID3Size, binaryISO85591ToString, binaryUTF8ToString, base64ToUint8A
 
 const DETECT_TIMEUPDATE_SEEKING_RANGE = 1;
 
-interface RendererOption {
+export interface RendererOption {
   width?: number,
   height?: number,
   data_identifier?: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { default as CanvasRenderer } from './canvas-renderer'
-export { default as CanvasProvider } from './canvas-provider'
+export { default as CanvasRenderer, RendererOption as CanvasRendererOption } from './canvas-renderer'
+export { default as CanvasProvider, ProviderOption as CanvasProviderOption, ProviderResult as CanvasProviderResult } from './canvas-provider'
 
-export { default as SVGRenderer } from './svg-renderer'
-export { default as SVGProvider } from './svg-provider'
+export { default as SVGRenderer, RendererOption as SVGRendererOption } from './svg-renderer'
+export { default as SVGProvider, ProviderOption as SVGProviderOption, ProviderResult as SVGProviderResult } from './svg-provider'

--- a/src/svg-provider.ts
+++ b/src/svg-provider.ts
@@ -36,7 +36,7 @@ type Region = {
   font?: string,
 }
 
-interface ProviderOption {
+export interface ProviderOption {
   svg?: SVGElement,
   data_identifier?: number,
   data_group_id?: number,
@@ -50,7 +50,7 @@ interface ProviderOption {
   usePUA?: boolean,
 }
 
-interface ProviderResult {
+export interface ProviderResult {
   startTime: number,
   endTime: number,
   PRA: number | null

--- a/src/svg-renderer.ts
+++ b/src/svg-renderer.ts
@@ -5,7 +5,7 @@ import { readID3Size, binaryISO85591ToString, binaryUTF8ToString, base64ToUint8A
 
 const DETECT_TIMEUPDATE_SEEKING_RANGE = 1;
 
-interface RendererOption {
+export interface RendererOption {
   data_identifier?: number,
   data_group_id?: number,
   forceStrokeColor?: string,


### PR DESCRIPTION
RendererOptionやProviderOptionの型を得るために`type RendererOption = ConstructorParameters<typeof aribb24js.CanvasRenderer>[0];`のようにしなくて済むようにします。