### PR TITLE
prevent infinite loops due to unexpected caption statements

### DIFF
--- a/src/canvas-provider.ts
+++ b/src/canvas-provider.ts
@@ -508,6 +508,8 @@ export default class CanvasProvider {
             this.G_BACK[0] = G_SET_BY_F.get(this.pes[begin + 2])
             begin += 3
           }
+        } else {
+          return
         }
       } else if (this.pes[begin] === JIS8.APS) {
         const P1 = this.pes[begin + 1] & 0x3F
@@ -792,6 +794,8 @@ export default class CanvasProvider {
         }else{
           return
         }
+      } else {
+        return
       }
     }
   }

--- a/src/svg-provider.ts
+++ b/src/svg-provider.ts
@@ -615,6 +615,8 @@ export default class CanvasProvider {
             this.G_BACK[0] = G_SET_BY_F.get(this.pes[begin + 2])
             begin += 3
           }
+        } else {
+          return
         }
       } else if (this.pes[begin] === JIS8.APS) {
         const P1 = this.pes[begin + 1] & 0x3F
@@ -936,6 +938,8 @@ export default class CanvasProvider {
         }else{
           return
         }
+      } else {
+        return
       }
     }
   }


### PR DESCRIPTION
Because of transmission errors, unsupported formats, etc.., if caption statements are something unexpected, the `parseText()` causes infinite loops easily.