### PR TITLE
add rendered text callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ It is alternative implementation for [b24.js](https://github.com/xqq/b24.js).
 * drcsReplacement: Replace DRCS to text if possible
 * drcsReplaceMapping: add more DRCS Mapping by Object (ex. { md5: character })
     * currently, replace to full-width character only supported.
+* renderedTextCallback: specify rendered text callback
+    * Type Definition is renderedText (renderedText: string) => unknown
 * PRACallback: specify PRA callback for SuperImpose
     * Type Definition is PRA (index: number) => unknown
 * keepAspectRatio: keep caption's aspect ratio in any container. (default: true)

--- a/src/canvas-renderer.ts
+++ b/src/canvas-renderer.ts
@@ -16,6 +16,7 @@ export interface RendererOption {
   gaijiFont?: string,
   drcsReplacement?: boolean,
   drcsReplaceMapping?: Record<string, string>,
+  renderedTextCallback?: (renderedText: string) => unknown,
   PRACallback?: (index: number) => unknown,
   keepAspectRatio?: boolean,
   enableRawCanvas?: boolean,
@@ -182,7 +183,7 @@ export default class CanvasID3Renderer {
 
   public pushID3v2Data(pts: number, data: Uint8Array): boolean {
     let result = false;
-    
+
     for (let begin = 0; begin < data.length;) {
       const id3_start = begin;
 
@@ -393,6 +394,10 @@ export default class CanvasID3Renderer {
             height: this.rendererOption?.height ?? this.viewCanvas.height,
           })
 
+          if (result?.renderedText != null) {
+            this.rendererOption?.renderedTextCallback?.(result?.renderedText);
+          }
+
           if (result?.PRA != null) {
              this.rendererOption?.PRACallback?.(result.PRA);
           }
@@ -418,7 +423,7 @@ export default class CanvasID3Renderer {
       for (let i = this.b24Track.activeCues.length - 2; i >= 0; i--) {
         const cue = this.b24Track.activeCues[i]
         cue.endTime = Math.min(cue.endTime, lastCue.startTime)
-        if (cue.startTime === cue.endTime) { // .. if duplicate subtitle appeared 
+        if (cue.startTime === cue.endTime) { // .. if duplicate subtitle appeared
           this.b24Track.removeCue(cue);
         }
       }
@@ -433,13 +438,13 @@ export default class CanvasID3Renderer {
   }
 
   private onTimeupdate() {
-    if (!this.media) { return; } 
+    if (!this.media) { return; }
     if (this.prevCurrentTime == null) {
       this.prevCurrentTime = this.media.currentTime;
       return;
     }
-    
-    if (!this.id3Track || !this.id3Track.cues || this.id3Track.cues.length === 0) { 
+
+    if (!this.id3Track || !this.id3Track.cues || this.id3Track.cues.length === 0) {
       this.prevCurrentTime = this.media.currentTime;
       return;
     }
@@ -468,7 +473,7 @@ export default class CanvasID3Renderer {
         const currentTime = this.prevCurrentTime;
         const middle = Math.floor((begin + end) / 2);
         const startTime = cues[middle].startTime;
-  
+
         if (currentTime < startTime) {
           end = middle;
         } else {
@@ -483,7 +488,7 @@ export default class CanvasID3Renderer {
         const currentTime = this.media.currentTime;
         const middle = Math.floor((begin + end) / 2);
         const startTime = cues[middle].startTime;
-  
+
         if (currentTime < startTime) {
           end = middle;
         } else {

--- a/src/html-provider-experimental.ts
+++ b/src/html-provider-experimental.ts
@@ -41,7 +41,8 @@ export interface ProviderResult {
   startTime: number,
   endTime: number,
   rendered: boolean,
-  PRA: number | null
+  renderedText: string | null,
+  PRA: number | null,
 }
 
 export default class HTMLProvider {
@@ -108,6 +109,7 @@ export default class HTMLProvider {
   private timeElapsed: number = 0
   private endTime: number | null = null
   private rendered: boolean = false
+  private renderedText: string = ''
   private PRA: number | null = null
 
   private normalFont: string = 'monospace'
@@ -184,7 +186,7 @@ export default class HTMLProvider {
     const purpose_data_identifier = option?.data_identifier ?? 0x80; // default: caption
     const purpose_data_group_id = option?.data_group_id ?? 0x01; // default: 1st language
 
-    if (pes.length <= 0) { return false; }  
+    if (pes.length <= 0) { return false; }
     const data_identifier = pes[0];
     if(data_identifier !== purpose_data_identifier){
       return false;
@@ -267,7 +269,8 @@ export default class HTMLProvider {
       startTime: this.startTime,
       endTime: this.endTime ?? Number.POSITIVE_INFINITY,
       rendered: this.rendered,
-      PRA: this.PRA
+      renderedText: this.renderedText !== '' ? this.renderedText : null,
+      PRA: this.PRA,
     })
   }
 
@@ -1100,6 +1103,11 @@ export default class HTMLProvider {
   private renderFont(character: string): void {
     if (this.cells === null) { return; }
 
+    // append to rendered text (ignoring ruby character)
+    if (!(this.text_type === 'SSZ' && (HIRAGANA_MAPPING.includes(character) || KATAKANA_MAPPING.includes(character)))) {
+      this.renderedText += character;
+    }
+
     const useGaijiFont = ADDITIONAL_SYMBOLS_SET.has(character)
     const font = useGaijiFont ? this.gaijiFont : this.normalFont;
 
@@ -1152,7 +1160,7 @@ export default class HTMLProvider {
                 first = false
               }
             }
-         
+
             elem.style.textShadow = shadow
           }
 

--- a/src/html-renderer-experimental.ts
+++ b/src/html-renderer-experimental.ts
@@ -14,6 +14,7 @@ export interface RendererOption {
   gaijiFont?: string,
   drcsReplacement?: boolean,
   drcsReplaceMapping?: Record<string, string>,
+  renderedTextCallback?: (renderedText: string) => unknown,
   PRACallback?: (index: number) => unknown,
   keepAspectRatio?: boolean,
   enableAutoInBandMetadataTextTrackDetection?: boolean,
@@ -160,7 +161,7 @@ export default class HTMLID3Renderer {
 
   public pushID3v2Data(pts: number, data: Uint8Array): boolean {
     let result = false;
-    
+
     for (let begin = 0; begin < data.length;) {
       const id3_start = begin;
 
@@ -360,6 +361,10 @@ export default class HTMLID3Renderer {
           table: this.table ?? undefined,
         })
 
+        if (result?.renderedText != null) {
+          this.rendererOption?.renderedTextCallback?.(result?.renderedText);
+        }
+
         if (result?.PRA != null) {
            this.rendererOption?.PRACallback?.(result.PRA);
         }
@@ -373,7 +378,7 @@ export default class HTMLID3Renderer {
       for (let i = this.b24Track.activeCues.length - 2; i >= 0; i--) {
         const cue = this.b24Track.activeCues[i]
         cue.endTime = Math.min(cue.endTime, lastCue.startTime)
-        if (cue.startTime === cue.endTime) { // .. if duplicate subtitle appeared 
+        if (cue.startTime === cue.endTime) { // .. if duplicate subtitle appeared
           this.b24Track.removeCue(cue);
         }
       }
@@ -388,13 +393,13 @@ export default class HTMLID3Renderer {
   }
 
   private onTimeupdate() {
-    if (!this.media) { return; } 
+    if (!this.media) { return; }
     if (this.prevCurrentTime == null) {
       this.prevCurrentTime = this.media.currentTime;
       return;
     }
-    
-    if (!this.id3Track || !this.id3Track.cues || this.id3Track.cues.length === 0) { 
+
+    if (!this.id3Track || !this.id3Track.cues || this.id3Track.cues.length === 0) {
       this.prevCurrentTime = this.media.currentTime;
       return;
     }
@@ -423,7 +428,7 @@ export default class HTMLID3Renderer {
         const currentTime = this.prevCurrentTime;
         const middle = Math.floor((begin + end) / 2);
         const startTime = cues[middle].startTime;
-  
+
         if (currentTime < startTime) {
           end = middle;
         } else {
@@ -438,7 +443,7 @@ export default class HTMLID3Renderer {
         const currentTime = this.media.currentTime;
         const middle = Math.floor((begin + end) / 2);
         const startTime = cues[middle].startTime;
-  
+
         if (currentTime < startTime) {
           end = middle;
         } else {

--- a/src/svg-provider.ts
+++ b/src/svg-provider.ts
@@ -42,7 +42,8 @@ export interface ProviderResult {
   startTime: number,
   endTime: number,
   rendered: boolean,
-  PRA: number | null
+  renderedText: string | null,
+  PRA: number | null,
 }
 
 export default class SVGProvider {
@@ -109,6 +110,7 @@ export default class SVGProvider {
   private timeElapsed: number = 0
   private endTime: number | null = null
   private rendered: boolean = false
+  private renderedText: string = ''
   private PRA: number | null = null
 
   private normalFont: string = 'monospace'
@@ -185,7 +187,7 @@ export default class SVGProvider {
     const purpose_data_identifier = option?.data_identifier ?? 0x80; // default: caption
     const purpose_data_group_id = option?.data_group_id ?? 0x01; // default: 1st language
 
-    if (pes.length <= 0) { return false; }  
+    if (pes.length <= 0) { return false; }
     const data_identifier = pes[0];
     if(data_identifier !== purpose_data_identifier){
       return false;
@@ -270,7 +272,8 @@ export default class SVGProvider {
       startTime: this.startTime,
       endTime: this.endTime ?? Number.POSITIVE_INFINITY,
       rendered: this.rendered,
-      PRA: this.PRA
+      renderedText: this.renderedText !== '' ? this.renderedText : null,
+      PRA: this.PRA,
     })
   }
 
@@ -1121,6 +1124,12 @@ export default class SVGProvider {
   }
 
   private renderFont(character: string): void {
+
+    // append to rendered text (ignoring ruby character)
+    if (!(this.text_type === 'SSZ' && (HIRAGANA_MAPPING.includes(character) || KATAKANA_MAPPING.includes(character)))) {
+      this.renderedText += character;
+    }
+
     const useGaijiFont = ADDITIONAL_SYMBOLS_SET.has(character)
     const font = useGaijiFont ? this.gaijiFont : this.normalFont;
 
@@ -1133,7 +1142,7 @@ export default class SVGProvider {
     if (useGaijiFont) { character += '\u{fe0e}' }
 
     const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-    // text.setAttribute('x', `${this.position_x} + this.width() / 2`); // without Safari 
+    // text.setAttribute('x', `${this.position_x} + this.width() / 2`); // without Safari
     // text.setAttribute('y', `${this.position_y - this.height() / 2}`); // without Safari
     text.setAttribute('x', '0');
     text.setAttribute('y', '0');
@@ -1182,7 +1191,7 @@ export default class SVGProvider {
     const elem = document.createElementNS('http://www.w3.org/2000/svg', 'path')
     elem.setAttribute('d', path);
 
-    // elem.setAttribute('x', `${this.position_x`); // without Safari 
+    // elem.setAttribute('x', `${this.position_x`); // without Safari
     // elem.setAttribute('y', `${this.position_y - this.height()}`); // without Safari issue
     elem.setAttribute('x', '0');
     elem.setAttribute('y', '0');

--- a/src/svg-renderer.ts
+++ b/src/svg-renderer.ts
@@ -14,6 +14,7 @@ export interface RendererOption {
   gaijiFont?: string,
   drcsReplacement?: boolean,
   drcsReplaceMapping?: Record<string, string>,
+  renderedTextCallback?: (renderedText: string) => unknown,
   PRACallback?: (index: number) => unknown,
   keepAspectRatio?: boolean,
   enableAutoInBandMetadataTextTrackDetection?: boolean,
@@ -159,7 +160,7 @@ export default class SVGRenderer {
 
   public pushID3v2Data(pts: number, data: Uint8Array): boolean {
     let result = false;
-    
+
     for (let begin = 0; begin < data.length;) {
       const id3_start = begin;
 
@@ -358,10 +359,14 @@ export default class SVGRenderer {
             svg: this.svg
           })
 
+          if (result?.renderedText != null) {
+            this.rendererOption?.renderedTextCallback?.(result?.renderedText);
+          }
+
           if (result?.PRA != null) {
              this.rendererOption?.PRACallback?.(result.PRA);
           }
-          
+
           rendered = result?.rendered ?? false
         }
 
@@ -373,7 +378,7 @@ export default class SVGRenderer {
       for (let i = this.b24Track.activeCues.length - 2; i >= 0; i--) {
         const cue = this.b24Track.activeCues[i]
         cue.endTime = Math.min(cue.endTime, lastCue.startTime)
-        if (cue.startTime === cue.endTime) { // .. if duplicate subtitle appeared 
+        if (cue.startTime === cue.endTime) { // .. if duplicate subtitle appeared
           this.b24Track.removeCue(cue);
         }
       }
@@ -388,13 +393,13 @@ export default class SVGRenderer {
   }
 
   private onTimeupdate() {
-    if (!this.media) { return; } 
+    if (!this.media) { return; }
     if (this.prevCurrentTime == null) {
       this.prevCurrentTime = this.media.currentTime;
       return;
     }
-    
-    if (!this.id3Track || !this.id3Track.cues || this.id3Track.cues.length === 0) { 
+
+    if (!this.id3Track || !this.id3Track.cues || this.id3Track.cues.length === 0) {
       this.prevCurrentTime = this.media.currentTime;
       return;
     }
@@ -423,7 +428,7 @@ export default class SVGRenderer {
         const currentTime = this.prevCurrentTime;
         const middle = Math.floor((begin + end) / 2);
         const startTime = cues[middle].startTime;
-  
+
         if (currentTime < startTime) {
           end = middle;
         } else {
@@ -438,7 +443,7 @@ export default class SVGRenderer {
         const currentTime = this.media.currentTime;
         const middle = Math.floor((begin + end) / 2);
         const startTime = cues[middle].startTime;
-  
+
         if (currentTime < startTime) {
           end = middle;
         } else {


### PR DESCRIPTION
aribb24.js の初期化オプションに、字幕が描画/更新される毎に描画された字幕のテキストデータを取得できる `renderedTextCallback?: (renderedText: string) => unknown` を追加しました。

このコールバック関数を指定することで、(TVTest のパネルの字幕タブのように) 字幕が描画されたタイミングで随時字幕リストに字幕を追加したり、キャプチャする際に表示中の字幕をテキストで取得できるようになります。

なお、renderedTextCallback() で取得できるテキストからは、ルビ（と思われる文字）は除外しています。
厳密にルビ文字と判断しているわけではありませんが、「SSZ かつひらがな・カタカナの文字」で大方のルビは除去できそうだったので、ひとまずそのような実装としました。

CanvasRenderer では動作確認済みです。
それ以外の Renderer での動作は確認できていませんが、おそらく動くと思います。